### PR TITLE
Fixed 'pkg_resources not found in requirements.txt' by readthedocs.io

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ packaging>=21.2
 pep517>=0.12.0
 Pillow>=8.4.0
 pip>=21.3.1
-pkg_resources>=0.0.0
 pyparsing>=2.4.7
 python-dateutil>=2.8.2
 python-docx>=0.8.11


### PR DESCRIPTION
readthedocs.io complained about pkg_resources in requirements.txt. It turns out it is a global installed package in python distribution and does not need to be listed.
