### PR TITLE
Add CSV summary format

### DIFF
--- a/docs/usage/export-csv-summary.rst
+++ b/docs/usage/export-csv-summary.rst
@@ -1,0 +1,49 @@
+Export to Comma Separated Values sorted by Host
+-----------------------------------------------
+
+When passing the --format csv parameter, the tool will export reports in Comma Separated Values (CSV) format. If you use [-T summary] parameter, an executive report will be generated.
+
+The report is suitable for later processing/inclusion in monitoring tools.
+
+The CSV format is optimized for import in Excel.
+
+Examples
+^^^^^^^^
+
+Create CSV report from 1 OpenVAS XML report, using default settings
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+.. code-block:: bash
+
+   openvasreporting -i openvasreport.xml -f csv -T summary
+
+Create CSV report from multiple OpenVAS XML report, using default settings
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+.. code-block:: bash
+
+   openvasreporting -i *.xml -f csv -T summary
+   # OR
+   openvasreporting -i openvasreport.xml -i openvasreport1.xml -i openvasreport2.xml [-i ...] -f csv -T summary
+
+Create CSV report from 1 OpenVAS XML report, and reporting only severity level high and up
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+.. code-block:: bash
+
+   openvasreporting -i openvasreport.xml -o openvas_report -f csv -l h -T summary
+
+
+Result
+^^^^^^
+
+The final report will look similar to this:
+
+.. code-block:: bash
+   
+   level,count,host_count
+   critical,11,152
+   high,19,71
+   medium,22,134
+   low,2,49
+   none,0,0

--- a/openvasreporting/libs/config.py
+++ b/openvasreporting/libs/config.py
@@ -102,6 +102,8 @@ class Config(object):
             self.report_type = 'vulnerability'
         elif report_type == 'h' or report_type == 'host':
             self.report_type = 'host'
+        elif report_type == 's' or report_type == 'summary':
+            self.report_type = 'summary'
         else:
            raise ValueError("Expected host or vulnerability for report-type parameter but got '{}' instead.".format(report_type))
         
@@ -303,8 +305,8 @@ class Config_YAML(Config):
             self.format = 'xlsx'
             
         if 'reporttype' in yamldict:
-            if not yamldict['reporttype'] in ['vulnerability', 'host']:
-                raise ValueError("Invalid value for report type parameter, must be one of: vulnerability, host")
+            if not yamldict['reporttype'] in ['vulnerability', 'host', 'summary']:
+                raise ValueError("Invalid value for report type parameter, must be one of: vulnerability, host, summary")
             self.report_type = yamldict['reporttype']
         else:
             self.report_type = 'vulnerability'

--- a/openvasreporting/libs/parser.py
+++ b/openvasreporting/libs/parser.py
@@ -34,8 +34,9 @@ def parsers():
         """
         return {
             'vulnerability': openvas_parser_by_vuln,
-            'host': openvas_parser_by_host
-}
+            'host': openvas_parser_by_host,
+            'summary': openvas_parser_by_vuln
+        }
 
 def openvas_parser_by_vuln(config: Config):
     """

--- a/openvasreporting/openvasreporting.py
+++ b/openvasreporting/openvasreporting.py
@@ -45,7 +45,7 @@ the regex expressions will be matched against the name of the vulnerability\n"""
                         help="Template file for docx export\n", required=False,
                         default=None)
     parser.add_argument("-T", "--report-type", dest="report_type", help="Report by (v)ulnerability or by (h)ost\n",
-                        required=False, choices=['h', 'host', 'v', 'vulnerability'], default="vulnerability")
+                        required=False, choices=['h', 'host', 'v', 'vulnerability', 's', 'summary'], default="vulnerability")
     parser.add_argument("-n", "--network-include", dest="networks_included", 
                         help="Path to a file containing a list of network cidrs, ip ranges and ips to be included in the report\n",
                         required=False, default=None)

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,3 @@ six>=1.16.0
 tomli>=1.2.2
 wheel>=0.37.0
 XlsxWriter>=3.0.2
-pyyaml


### PR DESCRIPTION
As an operations person i would like to create simple graphs showing number of vulnerabilities and affected hosts over time and alert on conditions.

The usual approach is to load timeseries data into a monitoring solution (e.g. zabbix).

As such condensed high level overview of data is needed in an easily parsable format.

This pull request allows that.

 * Create new report type `summary`
 * Modify necessary config parsing
 * Create new exporter `summary-csv`
 * Reuse the vulnerability parser as we need the same data
 * Add documentation